### PR TITLE
fix: resolve npm publish issue by adding prettier-plugin-svelte

### DIFF
--- a/.changeset/silver-signs-happen.md
+++ b/.changeset/silver-signs-happen.md
@@ -1,7 +1,0 @@
----
-"@design-atlas/svelte": patch
-"@design-atlas/tokens": patch
-"@design-atlas/react": patch
----
-
-Fix release

--- a/apps/svelte-demo/CHANGELOG.md
+++ b/apps/svelte-demo/CHANGELOG.md
@@ -1,0 +1,9 @@
+# @design-atlas/svelte-demo
+
+## 0.0.2
+
+### Patch Changes
+
+- Updated dependencies [f934210]
+  - @design-atlas/svelte@0.0.2
+  - @design-atlas/tokens@0.0.2

--- a/apps/svelte-demo/package.json
+++ b/apps/svelte-demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@design-atlas/svelte-demo",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -23,10 +23,11 @@
     "smoke:all": "pnpm pack:all && pnpm smoke:react && pnpm smoke:svelte && pnpm smoke:tokens"
   },
   "devDependencies": {
+    "@changesets/cli": "^2.27.0",
     "eslint": "^9.18.0",
     "eslint-config-prettier": "^10.0.1",
     "prettier": "^3.4.2",
-    "@changesets/cli": "^2.27.0",
+    "prettier-plugin-svelte": "^3.4.0",
     "rimraf": "^5.0.0"
   }
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @design-atlas/react
+
+## 0.0.2
+
+### Patch Changes
+
+- f934210: Fix release

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@design-atlas/react",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "React components for Design Atlas design system",
   "type": "module",
   "main": "dist/index.cjs",

--- a/packages/svelte/CHANGELOG.md
+++ b/packages/svelte/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @design-atlas/svelte
+
+## 0.0.2
+
+### Patch Changes
+
+- f934210: Fix release

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@design-atlas/svelte",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Svelte components for Design Atlas design system",
   "type": "module",
   "svelte": "dist/index.js",

--- a/packages/tokens/CHANGELOG.md
+++ b/packages/tokens/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @design-atlas/tokens
+
+## 0.0.2
+
+### Patch Changes
+
+- f934210: Fix release

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@design-atlas/tokens",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Design tokens for Design Atlas design system",
   "type": "module",
   "main": "dist/tokens.json",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       prettier:
         specifier: ^3.4.2
         version: 3.6.2
+      prettier-plugin-svelte:
+        specifier: ^3.4.0
+        version: 3.4.0(prettier@3.6.2)(svelte@5.38.1)
       rimraf:
         specifier: ^5.0.0
         version: 5.0.10


### PR DESCRIPTION
This PR fixes the npm publish issue that was occurring in the release workflow.

**Problem:**
The  step was failing because Prettier couldn't find the  plugin. The plugin was only installed in the  package, but when changesets ran prettier from the root directory to format changelog files, it tried to load the plugin configuration from the svelte-demo directory but couldn't find the plugin.

**Solution:**
- Added  as a dev dependency at the root level
- This allows changesets to properly format changelog files without errors

**Changes:**
- Added  to root 
- Package versions bumped from 0.0.1 to 0.0.2 via changeset
- Generated changelog files for all packages

The release workflow should now complete successfully.